### PR TITLE
Add color support

### DIFF
--- a/figure.go
+++ b/figure.go
@@ -3,6 +3,7 @@ package figure
 import (
 	"io"
 	"log"
+	"reflect"
 	"strings"
 )
 
@@ -14,6 +15,7 @@ type figure struct {
 	phrase string
 	font
 	strict bool
+	color  string
 }
 
 func NewFigure(phrase, fontName string, strict bool) figure {
@@ -21,7 +23,18 @@ func NewFigure(phrase, fontName string, strict bool) figure {
 	if font.reverse {
 		phrase = reverse(phrase)
 	}
-	return figure{phrase, font, strict}
+	return figure{phrase: phrase, font: font, strict: strict}
+}
+
+func NewColorFigure(phrase, fontName string, color string, strict bool) figure {
+	color = strings.ToLower(color)
+	if _, found := colors[color]; !found {
+		log.Fatalf("invalid color. must be one of: %s", reflect.ValueOf(colors).MapKeys())
+	}
+
+	fig := NewFigure(phrase, fontName, strict)
+	fig.color = color
+	return fig
 }
 
 func NewFigureWithFont(phrase string, reader io.Reader, strict bool) figure {
@@ -29,7 +42,7 @@ func NewFigureWithFont(phrase string, reader io.Reader, strict bool) figure {
 	if font.reverse {
 		phrase = reverse(phrase)
 	}
-	return figure{phrase, font, strict}
+	return figure{phrase: phrase, font: font, strict: strict}
 }
 
 func (figure figure) Slicify() (rows []string) {

--- a/font.go
+++ b/font.go
@@ -10,6 +10,18 @@ import (
 
 const defaultFont = "standard"
 
+var colors = map[string]string{
+	"reset":  "\033[0m",
+	"red":    "\033[31m",
+	"green":  "\033[32m",
+	"yellow": "\033[33m",
+	"blue":   "\033[34m",
+	"purple": "\033[35m",
+	"cyan":   "\033[36m",
+	"gray":   "\033[37m",
+	"white":  "\033[97m",
+}
+
 type font struct {
 	name      string
 	height    int

--- a/public_methods.go
+++ b/public_methods.go
@@ -10,6 +10,9 @@ import (
 //stdout
 func (fig figure) Print() {
 	for _, printRow := range fig.Slicify() {
+		if fig.color != "" {
+			printRow = colors[fig.color] + printRow + colors["reset"]
+		}
 		fmt.Println(printRow)
 	}
 }


### PR DESCRIPTION
Wouldn't it be cool if we could print to the terminal with color? Credit
to @mzfr for the idea!

Now we can. This change adds a new property to Figures: color. And a
new initializer to create a figure with color: NewColorFigure.

When the color is valid, it will print in that color. This includes
Blink, Scroll, and Dance, in addition to plain old Print.