### PR TITLE
Add Windows support to Print() method

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/common-nighthawk/go-figure
+
+go 1.17
+
+require (
+	github.com/mattn/go-colorable v0.1.12 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
+	golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,8 @@
-module github.com/jj0e/go-figure
+module github.com/common-nighthawk/go-figure
 
 go 1.17
 
 require github.com/mattn/go-colorable v0.1.12
-
-replace github.com/common-nighthawk/go-figure => github.com/jj0e/go-figure v1.0.0
 
 require (
 	github.com/mattn/go-isatty v0.0.14 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
-module github.com/common-nighthawk/go-figure
+module github.com/jj0e/go-figure
 
 go 1.17
 
+require github.com/mattn/go-colorable v0.1.12
+
 require (
-	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.17
 
 require github.com/mattn/go-colorable v0.1.12
 
+replace github.com/common-nighthawk/go-figure => github.com/jj0e/go-figure v1.0.0
+
 require (
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,7 @@
+github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
+github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
+github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
+github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
+golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6 h1:foEbQz/B0Oz6YIqu/69kfXPYeFQAuuMYFkjaqXzl5Wo=
+golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/public_methods.go
+++ b/public_methods.go
@@ -17,7 +17,7 @@ func (fig figure) Print() {
 		if fig.color != "" {
 			printRow = colors[fig.color] + printRow + colors["reset"]
 		}
-		fmt.Println(Output, printRow)
+		fmt.Fprintln(Output, printRow)
 	}
 }
 

--- a/public_methods.go
+++ b/public_methods.go
@@ -5,7 +5,11 @@ import (
 	"io"
 	"strings"
 	"time"
+
+	"github.com/mattn/go-colorable"
 )
+
+var Output = colorable.NewColorableStdout()
 
 //stdout
 func (fig figure) Print() {
@@ -13,7 +17,7 @@ func (fig figure) Print() {
 		if fig.color != "" {
 			printRow = colors[fig.color] + printRow + colors["reset"]
 		}
-		fmt.Println(printRow)
+		fmt.Println(Output, printRow)
 	}
 }
 


### PR DESCRIPTION
As referenced in issue #17 color printing is not supported on Windows currently. Thanks to [go-colorable](https://github.com/mattn/go-colorable) we can easily fix this. I have only changed the Print() method as its the only one I'm personally using but feel free to apply this to other methods.