### PR TITLE
Fix the link in README for fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ You can point to a file the comes with this project
 or you can store the file anywhere you'd like and use that location.
 
 The font files are available in the [fonts folder](https://github.com/common-nighthawk/go-figure/tree/master/fonts)
-and on [figlet.org](http://www.figlet.org/fontdb.cgi).
+and on [figlet.org](https://www.figlet.org/cgi-bin/fontdb.cgi).
 
 Here are two examples--
 


### PR DESCRIPTION
This pull request updates a URL in the `README.md` file to use a secure HTTPS link and corrects the path to the font database on figlet.org. 

* Documentation update:
  * Changed the figlet.org font database link from HTTP to HTTPS and updated the URL path for improved accuracy and security in `README.md`.